### PR TITLE
Fix the version of library in gradle example so to use bundled Object.requireNonNull

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ repositories {
 dependencies {
     compile 'io.reactivex:rxandroid:0.24.0'
     //  compile 'io.reactivex:rxjava:1.0.5'
-    compile 'com.eccyan:rxjava-optional:1.1.0'
+    compile 'com.eccyan:rxjava-optional:1.1.2'
 }
 ```
 


### PR DESCRIPTION
Version up gradle example's version 1.1.0 -> 1.1.2 since 1.1.0 doesn't bundle com.eccyan.optional.utils.Objects.requireNonNull and Androids below API 19 won't execute this library
